### PR TITLE
fix: down migrations for school assessment mapping

### DIFF
--- a/migrations/default/1698933525402_alter_table_public_assessment_cycle_district_school_mapping_drop_column_district_id/down.sql
+++ b/migrations/default/1698933525402_alter_table_public_assessment_cycle_district_school_mapping_drop_column_district_id/down.sql
@@ -1,0 +1,8 @@
+alter table "public"."assessment_cycle_district_school_mapping" add constraint "assessment_cycle_district_school_cycle_id_district_id_udise_key" unique (udise, cycle_id, district_id);
+alter table "public"."assessment_cycle_district_school_mapping"
+  add constraint "assessment_cycle_district_school_mapping_district_id_fkey"
+  foreign key (district_id)
+  references "public"."districts"
+  (id) on update cascade on delete restrict;
+alter table "public"."assessment_cycle_district_school_mapping" alter column "district_id" drop not null;
+alter table "public"."assessment_cycle_district_school_mapping" add column "district_id" int4;

--- a/migrations/default/1698933525402_alter_table_public_assessment_cycle_district_school_mapping_drop_column_district_id/up.sql
+++ b/migrations/default/1698933525402_alter_table_public_assessment_cycle_district_school_mapping_drop_column_district_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."assessment_cycle_district_school_mapping" drop column "district_id" cascade;

--- a/migrations/default/1698986263642_create_index_assessment_cycle_district_school_mapping_udise_idx/down.sql
+++ b/migrations/default/1698986263642_create_index_assessment_cycle_district_school_mapping_udise_idx/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."assessment_cycle_district_school_mapping_udise_idx";

--- a/migrations/default/1698986263642_create_index_assessment_cycle_district_school_mapping_udise_idx/up.sql
+++ b/migrations/default/1698986263642_create_index_assessment_cycle_district_school_mapping_udise_idx/up.sql
@@ -1,0 +1,2 @@
+CREATE  INDEX "assessment_cycle_district_school_mapping_udise_idx" on
+  "public"."assessment_cycle_district_school_mapping" using btree ("udise");


### PR DESCRIPTION
Related to https://github.com/Mission-Prerna/nl-apis/issues/66

- Down migrations to remove district id
- Added index on `udise` column